### PR TITLE
refactor: lib/data に取得・リターン行列を集約（並列フェッチ）

### DIFF
--- a/generate_signal.js
+++ b/generate_signal.js
@@ -14,7 +14,10 @@ const { config } = require('./lib/config');
 const { LeadLagSignal } = require('./lib/pca');
 const { buildPortfolio, computePerformanceMetrics } = require('./lib/portfolio');
 const { correlationMatrixSample } = require('./lib/math');
-const { loadCSV, buildPaperAlignedReturnRows } = require('./lib/data');
+const {
+  fetchOhlcvForTickers,
+  buildReturnMatricesFromOhlcv
+} = require('./lib/data');
 
 const logger = createLogger('SignalGenerator');
 
@@ -39,85 +42,6 @@ const JP_ETF_NAMES = {
   '1629.T': '商社・卸売', '1630.T': '小売', '1631.T': '銀行',
   '1632.T': '証券・商品', '1633.T': '保険'
 };
-
-/**
- * Yahoo Financeからデータを取得
- */
-async function fetchData(ticker, days = 200) {
-  if (config.data.mode === 'csv') {
-    const filePath = path.join(path.resolve(config.data.dataDir), `${ticker}.csv`);
-    if (!fs.existsSync(filePath)) {
-      logger.error(`CSV not found: ${filePath}`);
-      return [];
-    }
-    try {
-      const rows = loadCSV(filePath).map(row => ({
-        date: String(row.Date || row.date || '').split('T')[0],
-        open: Number(row.Open ?? row.open),
-        high: Number(row.High ?? row.high),
-        low: Number(row.Low ?? row.low),
-        close: Number(row.Close ?? row.close),
-        volume: Number(row.Volume ?? row.volume ?? 0)
-      })).filter(r => r.date && Number.isFinite(r.close) && r.close > 0);
-      return days > 0 && rows.length > days ? rows.slice(-days) : rows;
-    } catch (error) {
-      logger.error(`Failed to load ${ticker}`, { error: error.message });
-      return [];
-    }
-  }
-
-  try {
-    const YahooFinance = require('yahoo-finance2').default;
-    const yahooFinance = new YahooFinance();
-
-    const endDate = new Date();
-    const startDate = new Date();
-    startDate.setDate(startDate.getDate() - days);
-
-    const result = await yahooFinance.chart(ticker, {
-      period1: startDate.toISOString().split('T')[0],
-      period2: endDate.toISOString().split('T')[0],
-      interval: '1d'
-    });
-
-    return result.quotes
-      .filter(q => q.close !== null && q.close > 0)
-      .map(q => ({
-        date: q.date.toISOString().split('T')[0],
-        open: q.open,
-        high: q.high,
-        low: q.low,
-        close: q.close,
-        volume: q.volume
-      }));
-  } catch (error) {
-    logger.error(`Failed to fetch ${ticker}`, { error: error.message });
-    return [];
-  }
-}
-
-/**
- * リターンを計算
- */
-function computeReturns(ohlc, type = 'cc') {
-  if (!ohlc || ohlc.length < 2) return [];
-
-  if (type === 'cc') {
-    const returns = [];
-    let prev = null;
-    for (const r of ohlc) {
-      if (prev !== null) {
-        returns.push({ date: r.date, return: (r.close - prev) / prev });
-      }
-      prev = r.close;
-    }
-    return returns;
-  } else {
-    return ohlc
-      .filter(r => r.open > 0)
-      .map(r => ({ date: r.date, return: (r.close - r.open) / r.open }));
-  }
-}
 
 /**
  * コマンドライン引数を解析
@@ -172,59 +96,30 @@ async function main() {
 
   logger.info('Signal generation started', options);
 
-  // データ取得
-  console.log('\n📡 Fetching data from Yahoo Finance...');
+  const winDays = options.windowLength + 50;
+  console.log('\n📡 Loading market data (parallel per region)...');
 
-  const usData = {};
+  const [usRes, jpRes] = await Promise.all([
+    fetchOhlcvForTickers(US_ETF_TICKERS, winDays, config),
+    fetchOhlcvForTickers(JP_ETF_TICKERS, winDays, config)
+  ]);
+
+  const usData = usRes.byTicker;
+  const jpData = jpRes.byTicker;
+  for (const [t, err] of Object.entries({ ...usRes.errors, ...jpRes.errors })) {
+    logger.error(`Data load failed: ${t}`, { error: err });
+  }
+
   for (const ticker of US_ETF_TICKERS) {
-    process.stdout.write(`  ${ticker}... `);
-    usData[ticker] = await fetchData(ticker, options.windowLength + 50);
-    console.log(`${usData[ticker].length} days`);
+    console.log(`  ${ticker}... ${usData[ticker].length} days`);
   }
-
-  const jpData = {};
   for (const ticker of JP_ETF_TICKERS) {
-    process.stdout.write(`  ${ticker}... `);
-    jpData[ticker] = await fetchData(ticker, options.windowLength + 50);
-    console.log(`${jpData[ticker].length} days`);
+    console.log(`  ${ticker}... ${jpData[ticker].length} days`);
   }
 
-  const usCC = {};
-  const jpCC = {};
-  const jpOC = {};
-
-  for (const t of US_ETF_TICKERS) {
-    usCC[t] = computeReturns(usData[t], 'cc');
-  }
-  for (const t of JP_ETF_TICKERS) {
-    jpCC[t] = computeReturns(jpData[t], 'cc');
-    jpOC[t] = computeReturns(jpData[t], 'oc');
-  }
-
-  const usMap = new Map();
-  for (const t of US_ETF_TICKERS) {
-    for (const r of usCC[t]) {
-      if (!usMap.has(r.date)) usMap.set(r.date, {});
-      usMap.get(r.date)[t] = r.return;
-    }
-  }
-  const jpCCMap = new Map();
-  const jpOCMap = new Map();
-  for (const t of JP_ETF_TICKERS) {
-    for (const r of jpCC[t]) {
-      if (!jpCCMap.has(r.date)) jpCCMap.set(r.date, {});
-      jpCCMap.get(r.date)[t] = r.return;
-    }
-    for (const r of jpOC[t]) {
-      if (!jpOCMap.has(r.date)) jpOCMap.set(r.date, {});
-      jpOCMap.get(r.date)[t] = r.return;
-    }
-  }
-
-  const { retUs, retJp } = buildPaperAlignedReturnRows(
-    usMap,
-    jpCCMap,
-    jpOCMap,
+  const { retUs, retJp } = buildReturnMatricesFromOhlcv(
+    usData,
+    jpData,
     US_ETF_TICKERS,
     JP_ETF_TICKERS,
     config.backtest.jpWindowReturn

--- a/lib/data.js
+++ b/lib/data.js
@@ -559,6 +559,146 @@ function filterTradingDays(dates, market = 'JP') {
   return dates.filter(date => isTradingDay(date, market));
 }
 
+/**
+ * CC / OC リターン系列（generate_signal / server と同一の寛容な挙動）
+ */
+function computeReturns(ohlc, type = 'cc') {
+  if (!ohlc || ohlc.length === 0) return [];
+  if (type === 'cc') {
+    if (ohlc.length < 2) return [];
+    try {
+      return computeCCReturns(ohlc);
+    } catch (e) {
+      logger.warn('computeReturns(cc) skipped', { error: e.message });
+      return [];
+    }
+  }
+  try {
+    return computeOCReturns(ohlc);
+  } catch (e) {
+    logger.warn('computeReturns(oc) skipped', { error: e.message });
+    return [];
+  }
+}
+
+/**
+ * Yahoo / CSV から OHLCV を取得（リトライは Yahoo のみ）
+ * @param {string} ticker
+ * @param {number} days カレンダー日ベースの窓（CSV 時は末尾スライスに使用）
+ * @param {object} appConfig lib/config の config オブジェクト
+ * @returns {Promise<{ data: Array, error: string|null }>}
+ */
+async function fetchTickerOhlcv(ticker, days, appConfig) {
+  if (appConfig.data.mode === 'csv') {
+    const filePath = path.join(path.resolve(appConfig.data.dataDir), `${ticker}.csv`);
+    if (!fs.existsSync(filePath)) {
+      logger.error(`CSV not found: ${filePath}`);
+      return { data: [], error: `CSV not found: ${filePath}` };
+    }
+    try {
+      const rows = loadCSV(filePath).map(row => ({
+        date: String(row.Date || row.date || '').split('T')[0],
+        open: Number(row.Open ?? row.open),
+        high: Number(row.High ?? row.high),
+        low: Number(row.Low ?? row.low),
+        close: Number(row.Close ?? row.close),
+        volume: Number(row.Volume ?? row.volume ?? 0)
+      })).filter(r => r.date && Number.isFinite(r.close) && r.close > 0);
+      const data = days > 0 && rows.length > days ? rows.slice(-days) : rows;
+      return { data, error: null };
+    } catch (error) {
+      logger.error(`Failed to load ${ticker}`, { error: error.message });
+      return { data: [], error: error.message };
+    }
+  }
+
+  try {
+    const YahooFinance = require('yahoo-finance2').default;
+    const yahooFinance = new YahooFinance();
+    const endDate = new Date();
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() - days);
+
+    const result = await fetchWithRetry(
+      () => yahooFinance.chart(ticker, {
+        period1: startDate.toISOString().split('T')[0],
+        period2: endDate.toISOString().split('T')[0],
+        interval: '1d'
+      }),
+      { maxRetries: 3, baseDelay: 1000 }
+    );
+
+    const data = result.quotes
+      .filter(q => q.close !== null && q.close > 0)
+      .map(q => ({
+        date: q.date.toISOString().split('T')[0],
+        open: q.open,
+        high: q.high,
+        low: q.low,
+        close: q.close,
+        volume: q.volume
+      }));
+
+    return { data, error: null };
+  } catch (error) {
+    logger.warn(`Failed to fetch ${ticker}`, { error: error.message });
+    return { data: [], error: error.message };
+  }
+}
+
+/**
+ * 複数ティッカーを並列取得
+ * @returns {Promise<{ byTicker: Object<string, Array>, errors: Object<string, string> }>}
+ */
+async function fetchOhlcvForTickers(tickers, days, appConfig) {
+  const results = await Promise.all(
+    tickers.map(t => fetchTickerOhlcv(t, days, appConfig))
+  );
+  const byTicker = {};
+  const errors = {};
+  tickers.forEach((t, i) => {
+    byTicker[t] = results[i].data;
+    if (results[i].error) errors[t] = results[i].error;
+  });
+  return { byTicker, errors };
+}
+
+/**
+ * OHLCV から日付→銘柄→リターンの Map を構築し、論文アライメント済み系列を返す
+ */
+function buildReturnMatricesFromOhlcv(usData, jpData, usTickers, jpTickers, jpWindowReturn = 'cc') {
+  const usMap = new Map();
+  const jpCCMap = new Map();
+  const jpOCMap = new Map();
+
+  for (const t of usTickers) {
+    for (const r of computeReturns(usData[t] || [], 'cc')) {
+      if (!usMap.has(r.date)) usMap.set(r.date, {});
+      usMap.get(r.date)[t] = r.return;
+    }
+  }
+  for (const t of jpTickers) {
+    const d = jpData[t] || [];
+    for (const r of computeReturns(d, 'cc')) {
+      if (!jpCCMap.has(r.date)) jpCCMap.set(r.date, {});
+      jpCCMap.get(r.date)[t] = r.return;
+    }
+    for (const r of computeReturns(d, 'oc')) {
+      if (!jpOCMap.has(r.date)) jpOCMap.set(r.date, {});
+      jpOCMap.get(r.date)[t] = r.return;
+    }
+  }
+
+  return buildPaperAlignedReturnRows(
+    usMap,
+    jpCCMap,
+    jpOCMap,
+    usTickers,
+    jpTickers,
+    jpWindowReturn
+  );
+}
+
 module.exports = {
   fetchWithRetry,
   alignDates,
@@ -569,6 +709,10 @@ module.exports = {
   saveCSV,
   computeCCReturns,
   computeOCReturns,
+  computeReturns,
+  fetchTickerOhlcv,
+  fetchOhlcvForTickers,
+  buildReturnMatricesFromOhlcv,
   buildReturnMatrix,
   transpose,
   fillForward,

--- a/server.js
+++ b/server.js
@@ -5,19 +5,13 @@
 
 'use strict';
 
-const fs = require('fs');
 const express = require('express');
 const cors = require('cors');
 const rateLimit = require('express-rate-limit');
-const path = require('path');
-
 // ライブラリ
 const { createLogger } = require('./lib/logger');
 const { config, validate } = require('./lib/config');
-const {
-  SubspaceRegularizedPCA,
-  LeadLagSignal
-} = require('./lib/pca');
+const { LeadLagSignal } = require('./lib/pca');
 const {
   buildPortfolio,
   computePerformanceMetrics,
@@ -30,8 +24,8 @@ const {
 } = require('./lib/math');
 const {
   fetchWithRetry,
-  loadCSV,
-  buildPaperAlignedReturnRows
+  fetchOhlcvForTickers,
+  buildReturnMatricesFromOhlcv
 } = require('./lib/data');
 
 const logger = createLogger('Server');
@@ -204,149 +198,6 @@ function toDisplayMetrics(raw, dayCount) {
 }
 
 // ============================================
-// データ取得
-// ============================================
-
-/**
- * Yahoo Finance からデータを取得（リトライ付き）
- * @param {string} ticker - ティッカー
- * @param {number} days - 取得日数
- * @returns {Promise<{data: Array, error: string|null}>}
- */
-async function fetchData(ticker, days = 200) {
-  if (config.data.mode === 'csv') {
-    const filePath = path.join(path.resolve(config.data.dataDir), `${ticker}.csv`);
-    if (!fs.existsSync(filePath)) {
-      return { data: [], error: `CSV not found: ${filePath}` };
-    }
-    try {
-      const rows = loadCSV(filePath).map(row => ({
-        date: String(row.Date || row.date || '').split('T')[0],
-        open: Number(row.Open ?? row.open),
-        high: Number(row.High ?? row.high),
-        low: Number(row.Low ?? row.low),
-        close: Number(row.Close ?? row.close),
-        volume: Number(row.Volume ?? row.volume ?? 0)
-      })).filter(r => r.date && Number.isFinite(r.close) && r.close > 0);
-
-      const data = days > 0 && rows.length > days ? rows.slice(-days) : rows;
-      return { data, error: null };
-    } catch (error) {
-      return { data: [], error: error.message };
-    }
-  }
-
-  try {
-    const YahooFinance = require('yahoo-finance2').default;
-    const yahooFinance = new YahooFinance();
-
-    const endDate = new Date();
-    const startDate = new Date();
-    startDate.setDate(startDate.getDate() - days);
-
-    const result = await fetchWithRetry(
-      () => yahooFinance.chart(ticker, {
-        period1: startDate.toISOString().split('T')[0],
-        period2: endDate.toISOString().split('T')[0],
-        interval: '1d'
-      }),
-      { maxRetries: 3, baseDelay: 1000 }
-    );
-
-    const data = result.quotes
-      .filter(q => q.close !== null && q.close > 0)
-      .map(q => ({
-        date: q.date.toISOString().split('T')[0],
-        open: q.open,
-        high: q.high,
-        low: q.low,
-        close: q.close,
-        volume: q.volume
-      }));
-
-    return { data, error: null };
-  } catch (error) {
-    logger.warn(`Failed to fetch data for ${ticker}`, { error: error.message });
-    return { data: [], error: error.message };
-  }
-}
-
-/**
- * リターンを計算
- */
-function computeReturns(ohlc, type = 'cc') {
-  if (!ohlc || ohlc.length < 2) return [];
-
-  if (type === 'cc') {
-    const returns = [];
-    let prev = null;
-    for (const r of ohlc) {
-      if (prev !== null) {
-        returns.push((r.close - prev) / prev);
-      }
-      prev = r.close;
-    }
-    return returns;
-  } else {
-    return ohlc
-      .filter(r => r.open > 0)
-      .map(r => (r.close - r.open) / r.open);
-  }
-}
-
-/**
- * リターンマトリックスを構築（日付アライメント改善版）
- */
-function buildReturnMatrices(usData, jpData) {
-  const usCC = {};
-  const jpCC = {};
-  const jpOC = {};
-
-  for (const t of US_ETF_TICKERS) {
-    usCC[t] = computeReturns(usData[t], 'cc');
-  }
-  for (const t of JP_ETF_TICKERS) {
-    jpCC[t] = computeReturns(jpData[t], 'cc');
-    jpOC[t] = computeReturns(jpData[t], 'oc');
-  }
-
-  // 日付マップ
-  const usMap = new Map();
-  const jpCCMap = new Map();
-  const jpOCMap = new Map();
-
-  for (const t of US_ETF_TICKERS) {
-    const data = usData[t];
-    for (let i = 1; i < data.length; i++) {
-      const ret = (data[i].close - data[i - 1].close) / data[i - 1].close;
-      if (!usMap.has(data[i].date)) usMap.set(data[i].date, {});
-      usMap.get(data[i].date)[t] = ret;
-    }
-  }
-
-  for (const t of JP_ETF_TICKERS) {
-    const data = jpData[t];
-    for (let i = 1; i < data.length; i++) {
-      const ccRet = (data[i].close - data[i - 1].close) / data[i - 1].close;
-      const ocRet = (data[i].close - data[i].open) / data[i].open;
-      if (!jpCCMap.has(data[i].date)) jpCCMap.set(data[i].date, {});
-      jpCCMap.get(data[i].date)[t] = ccRet;
-      if (!jpOCMap.has(data[i].date)) jpOCMap.set(data[i].date, {});
-      jpOCMap.get(data[i].date)[t] = ocRet;
-    }
-  }
-
-  return buildPaperAlignedReturnRows(
-    usMap,
-    jpCCMap,
-    jpOCMap,
-    US_ETF_TICKERS,
-    JP_ETF_TICKERS,
-    config.backtest.jpWindowReturn
-  );
-}
-
-// ============================================
 // API Endpoints
 // ============================================
 
@@ -384,28 +235,27 @@ app.post('/api/backtest', async (req, res) => {
       costs
     });
 
-    // データ取得
-    logger.info('Fetching US ETF data');
-    const usData = {};
-    for (const ticker of US_ETF_TICKERS) {
-      const usResult = await fetchData(ticker, chartDays);
-      if (usResult.error) {
-        logger.warn(`Failed to fetch US data for ${ticker}: ${usResult.error}`);
-      }
-      usData[ticker] = usResult.data;
+    logger.info('Fetching US/JP ETF data (parallel)');
+    const [usRes, jpRes] = await Promise.all([
+      fetchOhlcvForTickers(US_ETF_TICKERS, chartDays, config),
+      fetchOhlcvForTickers(JP_ETF_TICKERS, chartDays, config)
+    ]);
+    const usData = usRes.byTicker;
+    const jpData = jpRes.byTicker;
+    for (const [ticker, err] of Object.entries(usRes.errors)) {
+      logger.warn(`US data ${ticker}: ${err}`);
+    }
+    for (const [ticker, err] of Object.entries(jpRes.errors)) {
+      logger.warn(`JP data ${ticker}: ${err}`);
     }
 
-    logger.info('Fetching JP ETF data');
-    const jpData = {};
-    for (const ticker of JP_ETF_TICKERS) {
-      const jpResult = await fetchData(ticker, chartDays);
-      if (jpResult.error) {
-        logger.warn(`Failed to fetch JP data for ${ticker}: ${jpResult.error}`);
-      }
-      jpData[ticker] = jpResult.data;
-    }
-
-    const { retUs, retJp, retJpOc, dates } = buildReturnMatrices(usData, jpData);
+    const { retUs, retJp, retJpOc, dates } = buildReturnMatricesFromOhlcv(
+      usData,
+      jpData,
+      US_ETF_TICKERS,
+      JP_ETF_TICKERS,
+      config.backtest.jpWindowReturn
+    );
 
     logger.info(`Data loaded: ${dates.length} trading days`);
 
@@ -570,26 +420,24 @@ app.post('/api/signal', async (req, res) => {
 
     logger.info('Generating signal', signalConfig);
 
-    // データ取得
-    const usData = {};
-    const jpData = {};
-
-    for (const ticker of US_ETF_TICKERS) {
-      const usResult = await fetchData(ticker, signalConfig.windowLength + 50);
-      if (usResult.error) {
-        logger.warn(`Failed to fetch US data for ${ticker}: ${usResult.error}`);
-      }
-      usData[ticker] = usResult.data;
-    }
-    for (const ticker of JP_ETF_TICKERS) {
-      const jpResult = await fetchData(ticker, signalConfig.windowLength + 50);
-      if (jpResult.error) {
-        logger.warn(`Failed to fetch JP data for ${ticker}: ${jpResult.error}`);
-      }
-      jpData[ticker] = jpResult.data;
+    const winDays = signalConfig.windowLength + 50;
+    const [usRes, jpRes] = await Promise.all([
+      fetchOhlcvForTickers(US_ETF_TICKERS, winDays, config),
+      fetchOhlcvForTickers(JP_ETF_TICKERS, winDays, config)
+    ]);
+    const usData = usRes.byTicker;
+    const jpData = jpRes.byTicker;
+    for (const [ticker, err] of Object.entries({ ...usRes.errors, ...jpRes.errors })) {
+      logger.warn(`Signal data ${ticker}: ${err}`);
     }
 
-    const { retUs, retJp, dates } = buildReturnMatrices(usData, jpData);
+    const { retUs, retJp, dates } = buildReturnMatricesFromOhlcv(
+      usData,
+      jpData,
+      US_ETF_TICKERS,
+      JP_ETF_TICKERS,
+      config.backtest.jpWindowReturn
+    );
 
     if (retUs.length < signalConfig.windowLength) {
       return res.json({ error: 'データが不足しています', signals: [] });
@@ -623,22 +471,22 @@ app.post('/api/signal', async (req, res) => {
 
     signals.forEach((s, i) => s.rank = i + 1);
 
-    // 価格取得
     const YahooFinance = require('yahoo-finance2').default;
     const yahooFinance = new YahooFinance();
-    const prices = {};
-
-    for (const ticker of JP_ETF_TICKERS) {
-      try {
-        const quote = await fetchWithRetry(
-          () => yahooFinance.quote(ticker),
-          { maxRetries: 2, baseDelay: 500 }
-        );
-        prices[ticker] = quote.regularMarketPrice || 0;
-      } catch (e) {
-        prices[ticker] = 0;
-      }
-    }
+    const quoteResults = await Promise.all(
+      JP_ETF_TICKERS.map(async (ticker) => {
+        try {
+          const quote = await fetchWithRetry(
+            () => yahooFinance.quote(ticker),
+            { maxRetries: 2, baseDelay: 500 }
+          );
+          return [ticker, quote.regularMarketPrice || 0];
+        } catch {
+          return [ticker, 0];
+        }
+      })
+    );
+    const prices = Object.fromEntries(quoteResults);
 
     signals.forEach(s => {
       s.price = prices[s.ticker] || 0;


### PR DESCRIPTION
## 概要
PR #1 レビューで挙がっていた **generate_signal / server のデータ処理重複** と **直列 await の並列化** に対応します。

## 変更
- `lib/data.js`: `fetchTickerOhlcv`, `fetchOhlcvForTickers`, `computeReturns`（寛容ラッパ）, `buildReturnMatricesFromOhlcv` を追加
- `generate_signal.js`: 上記を利用。米・日それぞれ `Promise.all` で並列取得
- `server.js`: `/api/backtest` / `/api/signal` のチャート取得を米・日並列。JP 株価 quote も `Promise.all`
- server のリターン Map は raw OHLC ループではなく `computeReturns` 経由に統一（generate_signal と同一・論文アライメントと整合）

## 確認
`npm test` 済み

Made with [Cursor](https://cursor.com)